### PR TITLE
Update build status location

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/Netflix/pygenie.svg?branch=master)](https://travis-ci.org/Netflix/pygenie)
+[![Build Status](https://travis-ci.com/Netflix/pygenie.svg?branch=master)](https://travis-ci.com/Netflix/pygenie)
 [![NetflixOSS Lifecycle](https://img.shields.io/osslifecycle/Netflix/pygenie.svg)]()
 [![Genie Client](https://img.shields.io/pypi/v/nflx_genie_client.svg)]()
 


### PR DESCRIPTION
This build has been migrated to travis-ci.com as per their [recommendation](https://mailchi.mp/3d439eeb1098/travis-ciorg-is-moving-to-travis-cicom).